### PR TITLE
大字町丁目名カナ、大字町丁目名ローマ字の出力

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -136,12 +136,12 @@ const normalizePostalValue = text => {
 }
 
 const removeChome = text => {
-  const regexp = /[二三四五六七八九]?十?[一二三四五六七八九]?丁目$/
+  const regexp = /[二三四五六七八九]?十?[一二三四五六七八九]?丁目?$/
   return text.replace(regexp, '')
 }
 
 const getChomeNumber = (text, suffix = '') => {
-  const regexp = /([二三四五六七八九]?十?[一二三四五六七八九]?)丁目$/
+  const regexp = /([二三四五六七八九]?十?[一二三四五六七八九]?)丁目?$/
   const match = text.match(regexp)
   if (match && match[1]) {
     return kanji2number(match[1]) + suffix
@@ -405,10 +405,10 @@ const getOazaAddressItems = async (prefCode, postalCodeKanaItems, postalCodeRome
         : '',
       line['大字町丁目名'],
       postalCodeKanaItem
-        ? han2zen(removeStringEnclosedInParentheses(postalCodeKanaItem['町域名カナ'])) + getChomeNumber(line['大字町丁目名'], 'チョウメ')
+        ? han2zen(removeStringEnclosedInParentheses(postalCodeKanaItem['町域名カナ'])) + (getChomeNumber(line['大字町丁目名']) !== '' ? ` ${getChomeNumber(line['大字町丁目名'])}` : '')
         : '',
       postalCodeRomeItem
-        ? removeStringEnclosedInParentheses(postalCodeRomeItem['町域名ローマ字']) + getChomeNumber(line['大字町丁目名'])
+        ? removeStringEnclosedInParentheses(postalCodeRomeItem['町域名ローマ字']) + (getChomeNumber(line['大字町丁目名']) !== '' ? ` ${getChomeNumber(line['大字町丁目名'])}` : '')
         : '',
     ]
       .map(item =>
@@ -494,10 +494,10 @@ const getGaikuAddressItems = async (prefCode, postalCodeKanaItems, postalCodeRom
         : '',
       townName,
       postalCodeKanaItem
-        ? han2zen(removeStringEnclosedInParentheses(postalCodeKanaItem['町域名カナ'])) + getChomeNumber(townName, 'チョウメ')
+        ? han2zen(removeStringEnclosedInParentheses(postalCodeKanaItem['町域名カナ'])) + (getChomeNumber(townName) !== '' ? ` ${getChomeNumber(townName)}` : '')
         : '',
       postalCodeRomeItem
-        ? removeStringEnclosedInParentheses(postalCodeRomeItem['町域名ローマ字']) + getChomeNumber(townName)
+        ? removeStringEnclosedInParentheses(postalCodeRomeItem['町域名ローマ字']) + (getChomeNumber(townName) !== '' ? ` ${getChomeNumber(townName)}` : '')
         : '',
     ]
       .map(item =>

--- a/bin/build.js
+++ b/bin/build.js
@@ -10,6 +10,7 @@ const iconv = require('iconv-lite')
 const csvParse = require('csv-parse/lib/sync')
 const cliProgress = require('cli-progress')
 const performance = require('perf_hooks').performance
+const kanji2number = require('@geolonia/japanese-numeral').kanji2number
 
 const dataDir = path.join(path.dirname(path.dirname(__filename)), 'data')
 
@@ -139,6 +140,16 @@ const removeChome = text => {
   return text.replace(regexp, '')
 }
 
+const getChomeNumber = (text, suffix = '') => {
+  const regexp = /([二三四五六七八九]?十?[一二三四五六七八九]?)丁目$/
+  const match = text.match(regexp)
+  if (match && match[1]) {
+    return kanji2number(match[1]) + suffix
+  } else {
+    return ''
+  }
+}
+
 const removeStringEnclosedInParentheses = text => {
   const regexp = /\(.+\)$/
   return text.replace(regexp, '')
@@ -172,8 +183,12 @@ const getPostalKanaOrRomeItems = (
           item['市区町村名'] === postalAlt.postal
         ,
       )
-      postalRecord['町域名カナ'] = ''
-      postalRecord['町域名ローマ字'] = ''
+      if (postalRecord['町域名カナ']) {
+        postalRecord['町域名カナ'] = ''
+      }
+      if (postalRecord['町域名ローマ字']) {
+        postalRecord['町域名ローマ字'] = ''
+      }
     }
 
     if (postalRecord && postalAlt[altKanaOrRomeCityFieldName]) {
@@ -197,8 +212,12 @@ const getPostalKanaOrRomeItems = (
           item['市区町村名'] === cityName
         ,
       )
-      postalRecord['町域名カナ'] = ''
-      postalRecord['町域名ローマ字'] = ''
+      if (postalRecord['町域名カナ']) {
+        postalRecord['町域名カナ'] = ''
+      }
+      if (postalRecord['町域名ローマ字']) {
+        postalRecord['町域名ローマ字'] = ''
+      }
     }
     return postalRecord
   }
@@ -386,10 +405,10 @@ const getOazaAddressItems = async (prefCode, postalCodeKanaItems, postalCodeRome
         : '',
       line['大字町丁目名'],
       postalCodeKanaItem
-        ? han2zen(removeStringEnclosedInParentheses(postalCodeKanaItem['町域名カナ']))
+        ? han2zen(removeStringEnclosedInParentheses(postalCodeKanaItem['町域名カナ'])) + getChomeNumber(line['大字町丁目名'], 'チョウメ')
         : '',
       postalCodeRomeItem
-        ? removeStringEnclosedInParentheses(postalCodeRomeItem['町域名ローマ字'])
+        ? removeStringEnclosedInParentheses(postalCodeRomeItem['町域名ローマ字']) + getChomeNumber(line['大字町丁目名'])
         : '',
     ]
       .map(item =>
@@ -475,10 +494,10 @@ const getGaikuAddressItems = async (prefCode, postalCodeKanaItems, postalCodeRom
         : '',
       townName,
       postalCodeKanaItem
-        ? han2zen(removeStringEnclosedInParentheses(postalCodeKanaItem['町域名カナ']))
+        ? han2zen(removeStringEnclosedInParentheses(postalCodeKanaItem['町域名カナ'])) + getChomeNumber(townName, 'チョウメ')
         : '',
       postalCodeRomeItem
-        ? removeStringEnclosedInParentheses(postalCodeRomeItem['町域名ローマ字'])
+        ? removeStringEnclosedInParentheses(postalCodeRomeItem['町域名ローマ字']) + getChomeNumber(townName)
         : '',
     ]
       .map(item =>

--- a/bin/build.js
+++ b/bin/build.js
@@ -134,9 +134,20 @@ const normalizePostalValue = text => {
   return text.replace('　', '').trim()
 }
 
+const removeChome = text => {
+  const regexp = /[二三四五六七八九]?十?[一二三四五六七八九]?丁目$/
+  return text.replace(regexp, '')
+}
+
+const removeStringEnclosedInParentheses = text => {
+  const regexp = /\(.+\)$/
+  return text.replace(regexp, '')
+}
+
 const getPostalKanaOrRomeItems = (
   prefName,
   cityName,
+  townName,
   postalCodeKanaOrRomeItems,
   postalKanaOrRomeCityFieldName,
   altKanaOrRomeCityFieldName,
@@ -146,12 +157,24 @@ const getPostalKanaOrRomeItems = (
   )
 
   if (postalAlt) {
-    const postalRecord = postalCodeKanaOrRomeItems.find(
+    let postalRecord = postalCodeKanaOrRomeItems.find(
       item =>
         item['都道府県名'] === prefName &&
-        item['市区町村名'] === postalAlt.postal
+        item['市区町村名'] === postalAlt.postal &&
+        item['町域名'].indexOf(removeChome(townName)) === 0
       ,
     )
+
+    if (!postalRecord) {
+      postalRecord = postalCodeKanaOrRomeItems.find(
+        item =>
+          item['都道府県名'] === prefName &&
+          item['市区町村名'] === postalAlt.postal
+        ,
+      )
+      postalRecord['町域名カナ'] = ''
+      postalRecord['町域名ローマ字'] = ''
+    }
 
     if (postalRecord && postalAlt[altKanaOrRomeCityFieldName]) {
       postalRecord[postalKanaOrRomeCityFieldName] = postalAlt[altKanaOrRomeCityFieldName]
@@ -159,12 +182,24 @@ const getPostalKanaOrRomeItems = (
 
     return postalRecord
   } else {
-    const postalRecord = postalCodeKanaOrRomeItems.find(
+    let postalRecord = postalCodeKanaOrRomeItems.find(
       item =>
         item['都道府県名'] === prefName &&
-        item['市区町村名'] === cityName
+        item['市区町村名'] === cityName &&
+        item['町域名'].indexOf(removeChome(townName)) === 0
       ,
     )
+
+    if (!postalRecord) {
+      postalRecord = postalCodeKanaOrRomeItems.find(
+        item =>
+          item['都道府県名'] === prefName &&
+          item['市区町村名'] === cityName
+        ,
+      )
+      postalRecord['町域名カナ'] = ''
+      postalRecord['町域名ローマ字'] = ''
+    }
     return postalRecord
   }
 }
@@ -321,10 +356,10 @@ const getOazaAddressItems = async (prefCode, postalCodeKanaItems, postalCodeRome
     const cityName = renameEntry ? renameEntry.renamed : line['市区町村名']
 
     const postalCodeKanaItem = getPostalKanaOrRomeItems(
-      line['都道府県名'], cityName, postalCodeKanaItems, '市区町村名カナ', 'kana',
+      line['都道府県名'], cityName, line['大字町丁目名'], postalCodeKanaItems, '市区町村名カナ', 'kana',
     )
     const postalCodeRomeItem = getPostalKanaOrRomeItems(
-      line['都道府県名'], cityName, postalCodeRomeItems, '市区町村名ローマ字', 'rome',
+      line['都道府県名'], cityName, line['大字町丁目名'], postalCodeRomeItems, '市区町村名ローマ字', 'rome',
     )
 
     if (!cityCodes[cityName]) {
@@ -350,8 +385,12 @@ const getOazaAddressItems = async (prefCode, postalCodeKanaItems, postalCodeRome
         ? postalCodeRomeItem['市区町村名ローマ字']
         : '',
       line['大字町丁目名'],
-      '',
-      ''
+      postalCodeKanaItem
+        ? han2zen(removeStringEnclosedInParentheses(postalCodeKanaItem['町域名カナ']))
+        : '',
+      postalCodeRomeItem
+        ? removeStringEnclosedInParentheses(postalCodeRomeItem['町域名ローマ字'])
+        : '',
     ]
       .map(item =>
         item && typeof item === 'string' ? `"${item}"` : item,
@@ -409,11 +448,12 @@ const getGaikuAddressItems = async (prefCode, postalCodeKanaItems, postalCodeRom
       continue
     }
 
+    const townName = line['大字・丁目名'] + line['小字・通称名']
     const postalCodeKanaItem = getPostalKanaOrRomeItems(
-      line['都道府県名'], cityName, postalCodeKanaItems, '市区町村名カナ', 'kana',
+      line['都道府県名'], cityName, townName, postalCodeKanaItems, '市区町村名カナ', 'kana',
     )
     const postalCodeRomeItem = getPostalKanaOrRomeItems(
-      line['都道府県名'], cityName, postalCodeRomeItems, '市区町村名ローマ字', 'rome',
+      line['都道府県名'], cityName, townName, postalCodeRomeItems, '市区町村名ローマ字', 'rome',
     )
 
     const record = [
@@ -433,9 +473,13 @@ const getGaikuAddressItems = async (prefCode, postalCodeKanaItems, postalCodeRom
       postalCodeRomeItem
         ? postalCodeRomeItem['市区町村名ローマ字']
         : '',
-      line['大字・丁目名'] + line['小字・通称名'],
-      '',
-      ''
+      townName,
+      postalCodeKanaItem
+        ? han2zen(removeStringEnclosedInParentheses(postalCodeKanaItem['町域名カナ']))
+        : '',
+      postalCodeRomeItem
+        ? removeStringEnclosedInParentheses(postalCodeRomeItem['町域名ローマ字'])
+        : '',
     ]
       .map(item =>
         item && typeof item === 'string' ? `"${item}"` : item,

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,11 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@geolonia/japanese-numeral": {
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/@geolonia/japanese-numeral/-/japanese-numeral-0.1.14.tgz",
+      "integrity": "sha512-LO1f4Bw/UF5OIWAavX9CyclxYCsHPDe6h/CWL/1RInc3QLMkEGicZp++qyfjodDsPKMCs84GReJapQnPWl3ZUQ=="
+    },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "unzipper": "^0.10.11"
   },
   "dependencies": {
+    "@geolonia/japanese-numeral": "^0.1.14",
     "cli-progress": "^3.8.2",
     "csv-parse": "^4.15.3",
     "encoding-japanese": "^1.0.30",


### PR DESCRIPTION
https://github.com/geolonia/japanese-addresses/issues/22 への対応。

以下の例のように大字町丁目名カナ、大字町丁目名ローマ字を出力するようにしました。
「○丁目」の部分のカナおよびローマ字のデータがないため、削っています。

```
"13","東京都","トウキョウト","TOKYO TO","13101","千代田区","チヨダク","CHIYODA KU","内幸町一丁目","ウチサイワイチョウ","UCHISAIWAICHO"
```