### PR TITLE
postalcode_roman.csvの「町域名」列のスペースも削除して正規化する

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -363,6 +363,7 @@ const downloadPostalCodeRome = async () => {
   }).map(item => ({
     ...item,
     市区町村名: normalizePostalValue(item['市区町村名']),
+    町域名: normalizePostalValue(item['町域名']),
   }))
   return json
 }


### PR DESCRIPTION
https://github.com/geolonia/japanese-addresses/issues/44 への対応