### PR TITLE
緯度・経度を数値型に統一する

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -593,8 +593,8 @@ const getGaikuAddressItems = async (prefCode, postalCodeKanaItems, postalCodeRom
         ? removeStringEnclosedInParentheses(postalCodeRomeItem['町域名ローマ字']) + (getChomeNumber(townName) !== '' ? ` ${getChomeNumber(townName)}` : '')
         : '',
       line['小字・通称名'],
-      String(center.geometry.coordinates[1]),
-      String(center.geometry.coordinates[0])
+      Number(center.geometry.coordinates[1]),
+      Number(center.geometry.coordinates[0])
     ]
       .map(item =>
         item && typeof item === 'string' ? `"${item}"` : item,

--- a/test/test-build.js
+++ b/test/test-build.js
@@ -10,16 +10,21 @@ describe('latest.csvのテスト', () => {
         encoding: 'utf-8',
       })
       .split(/\n/)
-    lines.shift() // 見出し行
   })
 
   it('一行目のデータを確認する', () => {
-    data = lines.shift()
+    data = lines[1]
     expect(data).to.equal('"20","長野県","ナガノケン","NAGANO KEN","20201","長野市","ナガノシ","NAGANO SHI","青木島二丁目","アオキジマ 2","AOKIJIMA 2",,36.617509,138.18148')
   })
 
   it('大字のローマ字を取得できる', () => {
-    data = lines[150]
+    data = lines[152]
     expect(data).to.equal('"20","長野県","ナガノケン","NAGANO KEN","20201","長野市","ナガノシ","NAGANO SHI","篠ノ井塩崎","シノノイシオザキ","SHINONOI SHIOZAKI",,36.552969,138.109935')
+  })
+
+  // https://github.com/geolonia/japanese-addresses/issues/57
+  it('緯度・経度は常に数値型', () => {
+    data = lines[2246]
+    expect(data).to.equal('"20","長野県","ナガノケン","NAGANO KEN","20201","長野市","ナガノシ","NAGANO SHI","篠ノ井塩崎","シノノイシオザキ","SHINONOI SHIOZAKI","四之宮",36.555444,138.10524')
   })
 })


### PR DESCRIPTION
https://github.com/geolonia/japanese-addresses/issues/57 で緯度・経度に文字列型と数値型が混在しているという指摘がありましたので、対応しました。