### PR TITLE
大字町丁名データの全角スペースを削除する。

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,6 @@ jobs:
       - run: mkdir data || true
       - run: npm install
       - name: Build Nagano data only
-        run: node bin/build.js 20
+        run: node bin/build.js 20,1
       - name: Test
         run: npx mocha

--- a/test/test-build.js
+++ b/test/test-build.js
@@ -27,4 +27,9 @@ describe('latest.csvのテスト', () => {
     data = lines[2245]
     expect(data).to.equal('"20","長野県","ナガノケン","NAGANO KEN","20201","長野市","ナガノシ","NAGANO SHI","篠ノ井塩崎","シノノイシオザキ","SHINONOI SHIOZAKI","四之宮",36.555444,138.10524')
   })
+
+  it('大字町丁名データの全角スペースを削除する', () => {
+    data = lines[24485]
+    expect(data).to.equal('"01","北海道","ホッカイドウ","HOKKAIDO","01632","河東郡士幌町","カトウグンシホロチョウ","KATO GUN SHIHORO CHO","字士幌仲通",,,,43.168944,143.246195')
+  })
 })


### PR DESCRIPTION
大字町丁名データの全角スペースを削除する。

関連Issue: https://github.com/geolonia/japanese-addresses/issues/88