### PR TITLE
市区町村コードが空欄となってしまうバグを修正

### DIFF
--- a/test/test-build.js
+++ b/test/test-build.js
@@ -32,4 +32,10 @@ describe('latest.csvのテスト', () => {
     data = lines[24485]
     expect(data).to.equal('"01","北海道","ホッカイドウ","HOKKAIDO","01632","河東郡士幌町","カトウグンシホロチョウ","KATO GUN SHIHORO CHO","字士幌仲通",,,,43.168944,143.246195')
   })
+
+  // https://github.com/geolonia/japanese-addresses/issues/97
+  it('上伊那郡南箕輪の市区町村コードが空欄にならない', () => {
+    data = lines[2632]
+    expect(data).to.equal('"20","長野県","ナガノケン","NAGANO KEN","20385","上伊那郡南箕輪村","カミイナグンミナミミノワムラ","KAMIINA GUN MINAMIMINOWA MURA","（大字なし）",,,,35.864863,137.960291')
+  })
 })


### PR DESCRIPTION
Closes #97 

市区町村名と市区町村コードの対応表は、これはまでは位置参照情報(大字・町丁目レベル)から作っていたのだが、「上伊那郡南箕輪村」は位置参照情報(大字・町丁目レベル)にはなく、位置参照情報(街区レベル)にしか登場しない市区町村だったため、市区町村コードが埋まっていなかった。修正するには、市区町村名と市区町村コードの対応表を ken_all.zip から作るように変更する必要がある。