### PR TITLE
住居表示住所 API 拡張

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ yarn.lock
 !/data/latest_v2.csv
 !/data/patch.json
 
+tmp

--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,7 @@ yarn.lock
 !/data/latest.csv
 !/data/latest_v2.csv
 !/data/patch.json
+住居表示.json
 
 tmp
+*.log

--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ https://geolonia.github.io/japanese-addresses/api/ja/<都道府県名>/<市区�
 * [国土交通省位置参照情報ダウンロードサイト](https://nlftp.mlit.go.jp/cgi-bin/isj/dls/_choose_method.cgi)
 * [郵便番号データダウンロード - 日本郵便](https://www.post.japanpost.jp/zipcode/download.html)
 
+また、住居表示住所 API は「アドレス・ベース・レジストリ」（デジタル庁）[住居表示住所・住居マスターデータセット](https://registry-catalog.registries.digital.go.jp/dataset?q=%E4%BD%8F%E5%B1%85%E8%A1%A8%E7%A4%BA&sort=metadata_modified+desc) をもとに株式会社 Geolonia が作成したものです。
+
 ## 貢献方法
 
 * 本データに不具合がある場合には、[Issue](https://github.com/geolonia/japanese-addresses/issues) または[プルリクエスト](https://github.com/geolonia/japanese-addresses/pulls)にてご報告ください。

--- a/bin/build-residential-api.mjs
+++ b/bin/build-residential-api.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+
+import fs from 'fs/promises'
+import unzip from 'unzipper'
+import csvParse from 'csv-parse/lib/sync.js'
+import { normalize, config } from '@geolonia/normalize-japanese-addresses'
+import process from 'process'
+import child_process from 'child_process'
+import os from 'os'
+import cluster from 'cluster'
+
+config.japaneseAddressesApi = `file://${process.cwd()}/api/ja`
+
+const csvDir = 'data/base-registry/mt_rsdtdsp_rsdt/city'
+const csvPosDir = 'data/base-registry/mt_rsdtdsp_rsdt_pos/city'
+
+let city2prefMap = undefined
+const city2pref = async (city) => {
+  if(!city2prefMap) {
+    city2prefMap = {}
+    const ja = JSON.parse(await fs.readFile('api/ja.json'))
+    for (const pref in ja) {
+      const cities = ja[pref];
+      for (const city of cities) {
+        city2prefMap[city] = pref
+      }
+    }
+  }
+  return city2prefMap[city]
+}
+
+/**
+ *
+ * @param {unzip.File} file
+ */
+const file2jyukyoCityTree = async (file, posFile) => {
+  const [buffer, posBuffer] = await Promise.all([file.buffer(), posFile.buffer()])
+  const items = csvParse(buffer, { columns: true, skip_empty_lines: true })
+  const posItems = csvParse(posBuffer, { columns: true, skip_empty_lines: true })
+
+  const posMap = new Map()
+  for (const posItem of posItems) {
+    if(posItem.代表点_座標参照系 !== 'EPSG:6668') {
+      throw new Error('Unexpected CRS.')
+    }
+    const key = [posItem.全国地方公共団体コード, posItem.町字id, posItem.街区id, posItem.住居id, posItem.住居2id].join('/')
+    const { 代表点_経度: lat, 代表点_緯度: lng } = posItem
+    posMap.set(key, { lat, lng })
+  }
+
+  const normalizedItems = []
+  for (const item of items) {
+    const _city = item.市区町村名 + item.政令市区名
+    const _pref = await city2pref(_city)
+    const _town = item['大字・町名'] + item.丁目名
+
+    const key = [item.全国地方公共団体コード, item.町字id, item.街区id, item.住居id, item.住居2id].join('/')
+    const { lat = null, lng = null } = posMap.get(key) || {}
+
+    const { pref, city, town } = await normalize(`${_pref || ''}${_city}${_town}`)
+    normalizedItems.push({...item, pref, city, town, gaiku: item.街区符号, jyukyo: item.住居番号, lat, lng })
+  }
+
+  const { pref, city } = normalizedItems[0]
+
+  const tree = normalizedItems.reduce((prev, item) => {
+    const { town, gaiku, jyukyo, lat, lng } = item
+    if(!prev[town]) {
+      prev[town] = []
+    }
+  prev[town].push({ gaiku, jyukyo, lat, lng })
+    return prev
+  }, {})
+  return { tree, pref, city }
+}
+
+const extendAPIwithResidentialInfo = async (tree, { pref, city }) => {
+  const cityDirname = `api/ja/${pref}/${city}`
+  await fs.mkdir(cityDirname, { recursive: true })
+  const cityList = JSON.parse(await fs.readFile(`api/ja/${pref}/${city}.json`))
+  for (const town in tree) {
+    if(!cityList.find((townItem) => townItem.town === town)) {
+      console.log(town, cityList.length)
+      console.warn(`Skipping unknown town name: ${pref}/${city}/${town}`)
+    } else {
+      const townDirname = `api/ja/${pref}/${city}/${town}`
+      const residentialFilename = `${townDirname}/住居表示.json`
+      const banchiGoItems = tree[town]
+
+      await fs.mkdir(townDirname, { recursive: true })
+      await fs.writeFile(residentialFilename, JSON.stringify(banchiGoItems))
+    }
+  }
+  await fs.writeFile(`api/ja/${pref}/${city}.json`, JSON.stringify(cityList.map(town => {
+    if(tree[town.town]) {
+      return { ...town, residential: true }
+    } else {
+      return town
+    }
+  })))
+}
+
+const main = async () => {
+  console.time('all')
+  const filenames = await fs.readdir(csvDir)
+
+  const promises = []
+
+  while (filenames.length > 0) {
+    const filename = filenames.shift()
+    if(!filename) continue;
+    promises.push(new Promise((resolve) => {
+      cluster
+        .fork({ FILENAME: filename })
+        .on('exit', resolve)
+    }))
+  }
+  await Promise.all(promises)
+  console.timeEnd('all')
+}
+
+const worker = async () => {
+  const filename = process.env.FILENAME
+  console.time(filename)
+  const posFilename = filename.replace('mt_rsdtdsp_rsdt_', 'mt_rsdtdsp_rsdt_pos_')
+  if(posFilename === filename) {
+    throw new Error(`Position not found: ${filename}.`)
+  }
+  const { files: [csvFile] } = await unzip.Open.file(`${csvDir}/${filename}`);
+  const { files: [csvPosFile] } = await unzip.Open.file(`${csvPosDir}/${posFilename}`);
+  try {
+    const { tree, pref, city } = await file2jyukyoCityTree(csvFile, csvPosFile)
+    await extendAPIwithResidentialInfo(tree, { pref, city })
+  } catch (error) {
+    console.error(error)
+  }
+  console.timeEnd(filename)
+  process.exit()
+}
+
+cluster.isWorker ? worker() : main()
+

--- a/bin/build.js
+++ b/bin/build.js
@@ -439,7 +439,7 @@ const getOazaAddressItems = async (prefCode, postalCodeKanaItems, postalCodeRome
 
     // 重複チェックに使用するためのキーには、「大字」または「字」を含めない。
     const oazaKey = townName.replace(/^大?字/g, '')
-    
+
     const recordKey = line['都道府県名'] + cityName + oazaKey
 
     // to avoid duplication
@@ -567,10 +567,10 @@ const getGaikuAddressItems = async (prefCode, postalCodeKanaItems, postalCodeRom
 
     // 重複チェックに使用するためのキーには、「大字」または「字」を含めない。
     const oazaKey = townName.replace(/^大?字/g, '')
-    
+
     const koazaName = line['小字・通称名'] === 'NULL' ? '' : line['小字・通称名']
     const recordKey = line['都道府県名'] + cityName + oazaKey + koazaName
-    
+
     // to avoid duplication
     if (records[recordKey]) {
       continue
@@ -656,6 +656,7 @@ const getAddressItems = async (
   )
 
   console.log(`${prefCode}: 街区レベル + 大字・町丁目レベル ${Object.values(gaikuData).length}件`)
+  // ここで住居表示住所が整備済みか入力する
 
   return gaikuData
 }
@@ -715,7 +716,8 @@ const main = async () => {
     '"大字町丁目名ローマ字"',
     '"小字・通称名"',
     '"緯度"',
-    '"経度"'
+    '"経度"',
+    '"住居表示"',
   ].join(',') + '\n')
 
   for (let i = 0; i < prefCodeArray.length; i++) {

--- a/bin/download-residential.sh
+++ b/bin/download-residential.sh
@@ -1,0 +1,31 @@
+ #!/bin/sh
+
+set -e
+
+mkdir -p tmp
+pushd tmp
+if [ ! -d base-registry-tools ]; then
+  git clone https://github.com/geolonia/base-registry-tools.git
+fi
+pushd base-registry-tools
+mkdir -p out
+docker build -t geolonia/base-registry-tools:latest .
+
+docker run --rm \
+  -v $(pwd):/scripts \
+  -v $(pwd)/out:/out \
+  -it geolonia/base-registry-tools \
+  /scripts/download_mt_rsdtdsp.py
+
+docker run --rm \
+  -v $(pwd):/scripts \
+  -v $(pwd)/out:/out \
+  -it geolonia/base-registry-tools \
+  /scripts/download_mt_rsdtdsp_pos.py
+popd
+popd
+
+if [ -d ./data/base-registry ]; then
+  rm -r ./data/base-registry
+fi
+mv ./tmp/base-registry-tools/out ./data/base-registry

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@geolonia/japanese-numeral": "^0.1.14",
-    "@geolonia/normalize-japanese-addresses": "^2.3.5",
+    "@geolonia/normalize-japanese-addresses": "^2.5.7",
     "@turf/center": "^6.3.0",
     "@turf/nearest-point": "^6.3.0",
     "async": "^3.2.0",


### PR DESCRIPTION
以下の静的 API 用ファイルを追加します。
```typescript
// api/ja/${都道府県}`${市区町村}${町丁目}/住居表示.json

{
  gaiku: string // 街区符号
  jyukyo: string // 住居番号
  lat: string // 緯度
  lng: string  // 経度
}[]
```

ビルド後の API フォルダが 1.7GB になること、 GitHub Pages で公開できないことから、 S3 等でホストすることを想定しています。