### PR TITLE
latest.csv の東京都渋谷区富ヶ谷、千駄ヶ谷、幡ヶ谷のカナおよびローマ字データが欠損しているバグを修正

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,6 @@ jobs:
       - run: mkdir data || true
       - run: npm install
       - name: Build Nagano, Hokkaido, and Nara data
-        run: node bin/build.js 20,1,29
+        run: node bin/build.js 20,1,29,13
       - name: Test
         run: npx mocha

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: mkdir data || true
       - run: npm install
-      - name: Build Nagano, Hokkaido, and Nara data
+      - name: Build Nagano, Hokkaido, Nara, and Tokyo data
         run: node bin/build.js 20,1,29,13
       - name: Test
         run: npx mocha

--- a/lib/get-postal-kana-or-rome-items.js
+++ b/lib/get-postal-kana-or-rome-items.js
@@ -1,0 +1,117 @@
+const cityNamePostalMappings = [
+  { pref: '青森県', postal: '東津軽郡外ヶ浜町', original: '東津軽郡外ケ浜町' },
+  { pref: '茨城県', postal: '龍ケ崎市', original: '龍ヶ崎市' },
+  { pref: '千葉県', postal: '鎌ケ谷市', original: '鎌ヶ谷市' },
+  { pref: '千葉県', postal: '袖ケ浦市', original: '袖ヶ浦市' },
+  { pref: '東京都', postal: '三宅島三宅村', original: '三宅村',
+    kana: 'ミヤケムラ', rome: 'MIYAKE MURA' },
+  { pref: '東京都', postal: '八丈島八丈町', original: '八丈町',
+    kana: 'ハチジョウマチ', rome: 'HACHIJO MACHI' },
+  { pref: '滋賀県', postal: '犬上郡多賀町', original: '犬上郡大字多賀町',
+    kana: 'イヌカミグンオオアザタガチョウ', rome: 'INUKAMI GUN OAZA TAGA CHO' },
+  { pref: '福岡県', postal: '糟屋郡須惠町', original: '糟屋郡須恵町' },
+]
+
+const townNamePostalMappings = [
+  { pref: '東京都', postal: '富ヶ谷', original: '富ケ谷' },
+  { pref: '東京都', postal: '幡ヶ谷', original: '幡ケ谷' },
+  { pref: '東京都', postal: '千駄ヶ谷', original: '千駄ケ谷' },
+]
+
+const REMOVE_STRING_STARTING_WITH_OPENING_PARENS_REGEX = /\(.+$/
+const removeStringStartingWithOpeningParentheses = text => {
+  return text.replace(REMOVE_STRING_STARTING_WITH_OPENING_PARENS_REGEX, '')
+}
+
+const REMOVE_CHOME_REGEX = /[二三四五六七八九]?十?[一二三四五六七八九]?丁目?$/
+const removeChome = text => text.replace(REMOVE_CHOME_REGEX, '')
+
+const getPostalKanaOrRomeItems = (
+  prefName,
+  cityName,
+  townName,
+  postalCodeKanaOrRomeItems,
+  postalKanaOrRomeCityFieldName,
+  altKanaOrRomeCityFieldName,
+) => {
+  let townNameChomeRemoved = removeChome(townName)
+
+  const townNamePostalAlt = townNamePostalMappings.find(
+    ({ pref, original }) => (pref === prefName && original === townNameChomeRemoved),
+  )
+
+  if (townNamePostalAlt) {
+    townNameChomeRemoved = townNamePostalAlt.postal
+  }
+  
+  const cityNamePostalAlt = cityNamePostalMappings.find(
+    ({ pref, original }) => (pref === prefName && original === cityName),
+  )
+
+  if (cityNamePostalAlt) {
+    let postalRecord = postalCodeKanaOrRomeItems.find(
+      item =>
+        item['都道府県名'] === prefName &&
+        item['市区町村名'] === cityNamePostalAlt.postal &&
+        item['町域名'].indexOf(townNameChomeRemoved) === 0
+      ,
+    )
+
+    if (!postalRecord) {
+      postalRecord = postalCodeKanaOrRomeItems.find(
+        item =>
+          item['都道府県名'] === prefName &&
+          item['市区町村名'] === cityNamePostalAlt.postal
+        ,
+      )
+      if (postalRecord['町域名カナ']) {
+        postalRecord['町域名カナ'] = ''
+      }
+      if (postalRecord['町域名ローマ字']) {
+        postalRecord['町域名ローマ字'] = ''
+      }
+    }
+
+    if (postalRecord && cityNamePostalAlt[altKanaOrRomeCityFieldName]) {
+      postalRecord[postalKanaOrRomeCityFieldName] = cityNamePostalAlt[altKanaOrRomeCityFieldName]
+    }
+
+    return postalRecord
+  } else {
+    let postalRecord = postalCodeKanaOrRomeItems.find(
+      item =>
+        item['都道府県名'] === prefName &&
+        item['市区町村名'] === cityName &&
+        item['町域名'].indexOf(townNameChomeRemoved) === 0
+      ,
+    )
+
+    if (!postalRecord) {
+      postalRecord = postalCodeKanaOrRomeItems.find(
+        item =>
+          item['都道府県名'] === prefName &&
+          item['市区町村名'] === cityName
+        ,
+      )
+      if (postalRecord['町域名カナ']) {
+        postalRecord['町域名カナ'] = ''
+      }
+      if (postalRecord['町域名ローマ字']) {
+        postalRecord['町域名ローマ字'] = ''
+      }
+    }
+
+    // 「ナカマチ(5115-5149、5171、5183、5186、」のような場合の「(」以降の不要な文字列を削除する。
+    if (postalRecord['町域名カナ']) {
+      postalRecord['町域名カナ'] = removeStringStartingWithOpeningParentheses(postalRecord['町域名カナ'])
+    }
+
+    if (postalRecord['町域名ローマ字']) {
+      postalRecord['町域名ローマ字'] = removeStringStartingWithOpeningParentheses(postalRecord['町域名ローマ字'])
+    }
+
+    return postalRecord
+  }
+}
+
+module.exports = getPostalKanaOrRomeItems

--- a/lib/get-postal-kana-or-rome-items.js
+++ b/lib/get-postal-kana-or-rome-items.js
@@ -12,12 +12,6 @@ const cityNamePostalMappings = [
   { pref: '福岡県', postal: '糟屋郡須惠町', original: '糟屋郡須恵町' },
 ]
 
-const townNamePostalMappings = [
-  { pref: '東京都', postal: '富ヶ谷', original: '富ケ谷' },
-  { pref: '東京都', postal: '幡ヶ谷', original: '幡ケ谷' },
-  { pref: '東京都', postal: '千駄ヶ谷', original: '千駄ケ谷' },
-]
-
 const REMOVE_STRING_STARTING_WITH_OPENING_PARENS_REGEX = /\(.+$/
 const removeStringStartingWithOpeningParentheses = text => {
   return text.replace(REMOVE_STRING_STARTING_WITH_OPENING_PARENS_REGEX, '')
@@ -34,15 +28,7 @@ const getPostalKanaOrRomeItems = (
   postalKanaOrRomeCityFieldName,
   altKanaOrRomeCityFieldName,
 ) => {
-  let townNameChomeRemoved = removeChome(townName)
-
-  const townNamePostalAlt = townNamePostalMappings.find(
-    ({ pref, original }) => (pref === prefName && original === townNameChomeRemoved),
-  )
-
-  if (townNamePostalAlt) {
-    townNameChomeRemoved = townNamePostalAlt.postal
-  }
+  let townNameRegExp = new RegExp('^' + removeChome(townName).replace(/[ヶケ]/, '[ヶケ]').replace(/[ヵカ]/, '[ヵカ]'))
   
   const cityNamePostalAlt = cityNamePostalMappings.find(
     ({ pref, original }) => (pref === prefName && original === cityName),
@@ -53,8 +39,7 @@ const getPostalKanaOrRomeItems = (
       item =>
         item['都道府県名'] === prefName &&
         item['市区町村名'] === cityNamePostalAlt.postal &&
-        item['町域名'].indexOf(townNameChomeRemoved) === 0
-      ,
+        townNameRegExp.test(item['町域名']),
     )
 
     if (!postalRecord) {
@@ -82,8 +67,7 @@ const getPostalKanaOrRomeItems = (
       item =>
         item['都道府県名'] === prefName &&
         item['市区町村名'] === cityName &&
-        item['町域名'].indexOf(townNameChomeRemoved) === 0
-      ,
+        townNameRegExp.test(item['町域名']),
     )
 
     if (!postalRecord) {

--- a/test/test-build.js
+++ b/test/test-build.js
@@ -29,7 +29,7 @@ describe('latest.csvのテスト', () => {
   })
 
   it('大字町丁名データの全角スペースを削除する', () => {
-    data = lines[21957]
+    data = lines[21958]
     expect(data).to.equal('"01","北海道","ホッカイドウ","HOKKAIDO","01632","河東郡士幌町","カトウグンシホロチョウ","KATO GUN SHIHORO CHO","字士幌仲通",,,,43.168944,143.246195')
   })
 

--- a/test/test-build.js
+++ b/test/test-build.js
@@ -18,30 +18,36 @@ describe('latest.csvのテスト', () => {
   })
 
   it('大字のローマ字を取得できる', () => {
-    data = lines[26372]
+    data = lines[31765]
     expect(data).to.equal('"20","長野県","ナガノケン","NAGANO KEN","20201","長野市","ナガノシ","NAGANO SHI","篠ノ井塩崎","シノノイシオザキ","SHINONOI SHIOZAKI",,36.552969,138.109935')
   })
 
   // https://github.com/geolonia/japanese-addresses/issues/57
   it('緯度・経度は常に数値型', () => {
-    data = lines[26375]
+    data = lines[31768]
     expect(data).to.equal('"20","長野県","ナガノケン","NAGANO KEN","20201","長野市","ナガノシ","NAGANO SHI","篠ノ井塩崎","シノノイシオザキ","SHINONOI SHIOZAKI","四之宮",36.555444,138.10524')
   })
 
   it('大字町丁名データの全角スペースを削除する', () => {
-    data = lines[21958]
+    data = lines[21957]
     expect(data).to.equal('"01","北海道","ホッカイドウ","HOKKAIDO","01632","河東郡士幌町","カトウグンシホロチョウ","KATO GUN SHIHORO CHO","字士幌仲通",,,,43.168944,143.246195')
   })
 
   // https://github.com/geolonia/japanese-addresses/issues/97
   it('上伊那郡南箕輪の市区町村コードが空欄にならない', () => {
-    data = lines[28471]
+    data = lines[33864]
     expect(data).to.equal('"20","長野県","ナガノケン","NAGANO KEN","20385","上伊那郡南箕輪村","カミイナグンミナミミノワムラ","KAMIINA GUN MINAMIMINOWA MURA","（大字なし）",,,,35.864863,137.960291')
   })
 
   // https://github.com/geolonia/japanese-addresses/issues/110
   it('ken_all.csv 由来の「(5115-5149、5171、5183、5186、」のような不要な文字列を削除する', () => {
-    data = lines[29230]
+    data = lines[34623]
     expect(data).to.equal('"29","奈良県","ナラケン","NARA KEN","29201","奈良市","ナラシ","NARA SHI","中町","ナカマチ","NAKAMACHI",,34.673048,135.747687')
+  })
+
+  // https://github.com/geolonia/japanese-addresses/issues/122
+  it('東京都渋谷区千駄ヶ谷のローマ字データが欠損していない', () => {
+    data = lines[27800]
+    expect(data).to.equal('"13","東京都","トウキョウト","TOKYO TO","13113","渋谷区","シブヤク","SHIBUYA KU","千駄ケ谷一丁目","センダガヤ 1","SENDAGAYA 1",,35.679251,139.710893')
   })
 })


### PR DESCRIPTION
郵便番号データを検索する前に、townNamePostalMappings で定義した変換表に従って、townName を変換するようにしました。
